### PR TITLE
Upgrade librato-collectd default version to Latest

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,9 +3,9 @@ node.default['librato']['repo_base'] = node['platform'] == 'amazon' ? 'librato-a
 
 case node['platform']
 when 'debian', 'ubuntu'
-  node.default['librato']['version'] = '5.5.0-librato51.251'
+  node.default['librato']['version'] = '5.7.1-librato1.413'
 when 'centos', 'redhat', 'fedora', 'amazon'
-  node.default['librato']['version'] = '5.5.0_librato51.251-0'
+  node.default['librato']['version'] = '5.7.1-librato1.413-0'
 end
 
 node.default['librato']['email'] = ''


### PR DESCRIPTION
Currently the librato attribute is pointing to an older version of the
collectd agent. This bumps it to the latest.